### PR TITLE
feat: Backporting `azure_management_api` and `azure_management_product` modules

### DIFF
--- a/api_management_api/README.md
+++ b/api_management_api/README.md
@@ -1,0 +1,113 @@
+# api management api
+
+This module allow the creation of api management product, and associate to a groups and create policy if requested
+
+## Architecture
+
+![This is an image](./docs/module-arch.drawio.png)
+
+## How to use it
+
+```ts
+locals {
+  apim_devopslab_webapp_python_alpha_api = {
+    # params for all api versions
+    display_name          = "Webapp Python Alpha api"
+    description           = "Webapp Python Alpha api"
+    path                  = "webapp-python-alpha"
+    subscription_required = false
+    service_url           = "http://mock-aks/webapp-python-alpha"
+    api_name              = "${var.env}-webapp-python-alpha-api"
+  }
+}
+
+# resource "azurerm_api_management_api_version_set" "apim_devopslab_webapp_python_alpha_api" {
+#   name                = local.apim_devopslab_webapp_python_alpha_api.api_name
+#   resource_group_name = module.apim.resource_group_name
+#   api_management_name = module.apim.name
+#   display_name        = local.apim_devopslab_webapp_python_alpha_api.display_name
+#   versioning_scheme   = "Segment"
+# }
+
+module "apim_devopslab_webapp_python_alpha_api_v1" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_api?ref=v8.8.0"
+
+  name                  = local.apim_devopslab_webapp_python_alpha_api.api_name
+  api_management_name   = module.apim.name
+  product_ids           = [module.apim_product_devopslab.product_id]
+  subscription_required = local.apim_devopslab_webapp_python_alpha_api.subscription_required
+  # version_set_id        = azurerm_api_management_api_version_set.apim_devopslab_webapp_python_alpha_api.id
+  # api_version           = "v1"
+  service_url         = "${local.apim_devopslab_webapp_python_alpha_api.service_url}/"
+  resource_group_name = module.apim.resource_group_name
+
+  description  = local.apim_devopslab_webapp_python_alpha_api.description
+  display_name = local.apim_devopslab_webapp_python_alpha_api.display_name
+  path         = local.apim_devopslab_webapp_python_alpha_api.path
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value = templatefile("./api/devopslab/webapp-python/openapi_webapp_python.json.tftpl", {
+    projectName = local.apim_devopslab_webapp_python_alpha_api.display_name
+  })
+
+  xml_content = file("./api/devopslab/webapp-python/_base_policy.xml")
+}
+
+```
+
+<!-- markdownlint-disable -->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_api_management_api.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api_operation_policy.api_operation_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
+| [azurerm_api_management_product_api.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_management_name"></a> [api\_management\_name](#input\_api\_management\_name) | n/a | `string` | n/a | yes |
+| <a name="input_api_operation_policies"></a> [api\_operation\_policies](#input\_api\_operation\_policies) | List of api policy for given operation. | <pre>list(object({<br/>    operation_id = string<br/>    xml_content  = string<br/>    }<br/>  ))</pre> | `[]` | no |
+| <a name="input_api_type"></a> [api\_type](#input\_api\_type) | (Optional) Type of API. Possible values are graphql, http, soap, and websocket. Defaults to http. | `string` | `"http"` | no |
+| <a name="input_api_version"></a> [api\_version](#input\_api\_version) | The Version number of this API, if this API is versioned. | `string` | `null` | no |
+| <a name="input_content_format"></a> [content\_format](#input\_content\_format) | The format of the content from which the API Definition should be imported. | `string` | `"swagger-json"` | no |
+| <a name="input_content_value"></a> [content\_value](#input\_content\_value) | The Content from which the API Definition should be imported. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | n/a | `string` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | n/a | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_oauth2_authorization"></a> [oauth2\_authorization](#input\_oauth2\_authorization) | n/a | <pre>object({<br/>    authorization_server_name = string<br/>    }<br/>  )</pre> | <pre>{<br/>  "authorization_server_name": null<br/>}</pre> | no |
+| <a name="input_path"></a> [path](#input\_path) | n/a | `string` | n/a | yes |
+| <a name="input_product_ids"></a> [product\_ids](#input\_product\_ids) | n/a | `list(string)` | `[]` | no |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | n/a | `list(string)` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
+| <a name="input_revision"></a> [revision](#input\_revision) | n/a | `string` | `"1"` | no |
+| <a name="input_revision_description"></a> [revision\_description](#input\_revision\_description) | n/a | `string` | `null` | no |
+| <a name="input_service_url"></a> [service\_url](#input\_service\_url) | n/a | `string` | n/a | yes |
+| <a name="input_subscription_key_names"></a> [subscription\_key\_names](#input\_subscription\_key\_names) | Override the default name of the header and query string containing the subscription key header | <pre>object({<br/>    header = string<br/>    query  = string<br/>  })</pre> | `null` | no |
+| <a name="input_subscription_required"></a> [subscription\_required](#input\_subscription\_required) | Should this API require a subscription key? | `bool` | `false` | no |
+| <a name="input_version_set_id"></a> [version\_set\_id](#input\_version\_set\_id) | The ID of the Version Set which this API is associated with. | `string` | `null` | no |
+| <a name="input_xml_content"></a> [xml\_content](#input\_xml\_content) | The XML Content for this Policy as a string | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/api_management_api/README.md
+++ b/api_management_api/README.md
@@ -30,7 +30,7 @@ locals {
 # }
 
 module "apim_devopslab_webapp_python_alpha_api_v1" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_api?ref=v8.8.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//api_management_api?ref=v1.0.0"
 
   name                  = local.apim_devopslab_webapp_python_alpha_api.api_name
   api_management_name   = module.apim.name

--- a/api_management_api/main.tf
+++ b/api_management_api/main.tf
@@ -1,0 +1,66 @@
+resource "azurerm_api_management_api" "this" {
+  name                 = var.api_version != null ? join("-", [var.name, var.api_version]) : var.name
+  resource_group_name  = var.resource_group_name
+  api_management_name  = var.api_management_name
+  revision             = var.revision
+  revision_description = var.revision_description
+  display_name         = var.display_name
+  description          = var.description
+  api_type             = var.api_type
+
+  dynamic "oauth2_authorization" {
+    for_each = var.oauth2_authorization.authorization_server_name != null ? ["dummy"] : []
+    content {
+      authorization_server_name = var.oauth2_authorization.authorization_server_name
+    }
+  }
+
+  path                  = var.path
+  protocols             = var.protocols
+  service_url           = var.service_url
+  subscription_required = var.subscription_required
+  version               = var.api_version
+  version_set_id        = var.version_set_id
+
+  import {
+    content_format = var.content_format
+    content_value  = var.content_value
+  }
+
+  dynamic "subscription_key_parameter_names" {
+    for_each = var.subscription_key_names == null ? [] : ["dummy"]
+    content {
+      header = var.subscription_key_names.header
+      query  = var.subscription_key_names.query
+    }
+  }
+}
+
+resource "azurerm_api_management_api_policy" "this" {
+  count               = var.xml_content == null ? 0 : 1
+  api_name            = azurerm_api_management_api.this.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+
+  xml_content = var.xml_content
+}
+
+resource "azurerm_api_management_product_api" "this" {
+  for_each = toset(var.product_ids)
+
+  product_id          = each.value
+  api_name            = azurerm_api_management_api.this.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_api_management_api_operation_policy" "api_operation_policy" {
+  for_each = { for p in var.api_operation_policies : format("%s%s", p.operation_id, var.api_version == null ? "" : var.api_version) => p }
+
+  api_name            = azurerm_api_management_api.this.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+  operation_id        = each.value.operation_id
+
+  xml_content = each.value.xml_content
+}

--- a/api_management_api/outputs.tf
+++ b/api_management_api/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = azurerm_api_management_api.this.id
+}
+
+output "name" {
+  value = azurerm_api_management_api.this.name
+}

--- a/api_management_api/variables.tf
+++ b/api_management_api/variables.tf
@@ -1,0 +1,116 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "api_management_name" {
+  type = string
+}
+
+variable "display_name" {
+  type = string
+}
+
+variable "description" {
+  type = string
+}
+
+variable "service_url" {
+  type = string
+}
+
+variable "revision" {
+  type    = string
+  default = "1"
+}
+
+variable "revision_description" {
+  type    = string
+  default = null
+}
+
+variable "api_type" {
+  type        = string
+  default     = "http"
+  description = "(Optional) Type of API. Possible values are graphql, http, soap, and websocket. Defaults to http."
+}
+
+variable "oauth2_authorization" {
+  type = object({
+    authorization_server_name = string
+    }
+  )
+  default = {
+    authorization_server_name = null
+  }
+}
+
+variable "path" {
+  type = string
+}
+
+variable "protocols" {
+  type = list(string)
+}
+
+variable "subscription_required" {
+  type        = bool
+  default     = false
+  description = "Should this API require a subscription key?"
+}
+
+variable "content_format" {
+  type        = string
+  description = "The format of the content from which the API Definition should be imported."
+  default     = "swagger-json"
+}
+
+variable "content_value" {
+  type        = string
+  description = "The Content from which the API Definition should be imported."
+}
+
+variable "xml_content" {
+  type        = string
+  description = "The XML Content for this Policy as a string"
+  default     = null
+}
+
+variable "product_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "api_operation_policies" {
+  type = list(object({
+    operation_id = string
+    xml_content  = string
+    }
+  ))
+  default     = []
+  description = "List of api policy for given operation."
+}
+
+variable "api_version" {
+  type        = string
+  description = "The Version number of this API, if this API is versioned."
+  default     = null
+}
+
+variable "version_set_id" {
+  type        = string
+  description = "The ID of the Version Set which this API is associated with."
+  default     = null
+}
+
+variable "subscription_key_names" {
+  type = object({
+    header = string
+    query  = string
+  })
+  description = "Override the default name of the header and query string containing the subscription key header"
+  default     = null
+}

--- a/api_management_api/versions.tf
+++ b/api_management_api/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4"
+    }
+  }
+}

--- a/api_management_product/README.md
+++ b/api_management_product/README.md
@@ -10,7 +10,7 @@ This module allow the creation of api management product, and associate to a gro
 
 ```ts
 module "apim_product_devopslab" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v8.8.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git//api_management_product?ref=v1.0.0"
 
   product_id   = "devopslab"
   display_name = "DevOpsLab Program"

--- a/api_management_product/README.md
+++ b/api_management_product/README.md
@@ -1,0 +1,74 @@
+# api management product
+
+This module allow the creation of api management product, and associate to a groups and create policy if requested
+
+## Architecture
+
+![This is an image](./docs/module-arch.drawio.png)
+
+## How to use it
+
+```ts
+module "apim_product_devopslab" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v8.8.0"
+
+  product_id   = "devopslab"
+  display_name = "DevOpsLab Program"
+  description  = "Product for DevOpsLab backend"
+
+  api_management_name = module.apim.name
+  resource_group_name = module.apim.resource_group_name
+
+  published             = true
+  subscription_required = true
+  approval_required     = false
+
+  policy_xml = file("./api_product/devopslab/_base_policy.xml")
+}
+
+```
+
+<!-- markdownlint-disable -->
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_api_management_product.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product) | resource |
+| [azurerm_api_management_product_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_group) | resource |
+| [azurerm_api_management_product_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_policy) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_management_name"></a> [api\_management\_name](#input\_api\_management\_name) | The name of the API Management Service. | `string` | n/a | yes |
+| <a name="input_approval_required"></a> [approval\_required](#input\_approval\_required) | Do subscribers need to be approved prior to being able to use the Product? | `bool` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | A description of this Product, which may include HTML formatting tags. | `string` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The Display Name for this API Management Product. | `string` | n/a | yes |
+| <a name="input_groups"></a> [groups](#input\_groups) | (Optional) The groups where the product is included | `set(string)` | `[]` | no |
+| <a name="input_policy_xml"></a> [policy\_xml](#input\_policy\_xml) | (Optional) The XML Content for this Product Policy. | `string` | `null` | no |
+| <a name="input_product_id"></a> [product\_id](#input\_product\_id) | The Identifier for this Product, which must be unique within the API Management Service. | `string` | n/a | yes |
+| <a name="input_published"></a> [published](#input\_published) | Is this Product Published? | `bool` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the Resource Group in which the API Management Service should be exist. | `string` | n/a | yes |
+| <a name="input_subscription_required"></a> [subscription\_required](#input\_subscription\_required) | Is a Subscription required to access API's included in this Product? | `bool` | n/a | yes |
+| <a name="input_subscriptions_limit"></a> [subscriptions\_limit](#input\_subscriptions\_limit) | The number of subscriptions a user can have to this Product at the same time. | `number` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_product_id"></a> [product\_id](#output\_product\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/api_management_product/main.tf
+++ b/api_management_product/main.tf
@@ -1,0 +1,34 @@
+resource "azurerm_api_management_product" "this" {
+  product_id          = var.product_id
+  api_management_name = var.api_management_name
+  display_name        = var.display_name
+  description         = var.description
+
+  subscription_required = var.subscription_required
+  subscriptions_limit   = var.subscriptions_limit
+  approval_required     = var.approval_required
+  published             = var.published
+
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_api_management_product_policy" "this" {
+  count = var.policy_xml == null ? 0 : 1
+
+  product_id          = azurerm_api_management_product.this.product_id
+  api_management_name = var.api_management_name
+
+  xml_content = var.policy_xml
+
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_api_management_product_group" "this" {
+  for_each = var.groups
+
+  product_id          = azurerm_api_management_product.this.product_id
+  api_management_name = var.api_management_name
+  group_name          = each.key
+
+  resource_group_name = var.resource_group_name
+}

--- a/api_management_product/outputs.tf
+++ b/api_management_product/outputs.tf
@@ -1,0 +1,7 @@
+output "id" {
+  value = azurerm_api_management_product.this.id
+}
+
+output "product_id" {
+  value = azurerm_api_management_product.this.product_id
+}

--- a/api_management_product/variables.tf
+++ b/api_management_product/variables.tf
@@ -1,0 +1,57 @@
+variable "product_id" {
+  type        = string
+  description = "The Identifier for this Product, which must be unique within the API Management Service."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of the Resource Group in which the API Management Service should be exist."
+}
+
+variable "api_management_name" {
+  type        = string
+  description = "The name of the API Management Service."
+}
+
+variable "display_name" {
+  type        = string
+  description = "The Display Name for this API Management Product."
+}
+
+variable "description" {
+  type        = string
+  description = "A description of this Product, which may include HTML formatting tags."
+}
+
+variable "subscription_required" {
+  type        = bool
+  description = "Is a Subscription required to access API's included in this Product?"
+}
+
+variable "subscriptions_limit" {
+  type        = number
+  description = "The number of subscriptions a user can have to this Product at the same time."
+  default     = null
+}
+
+variable "approval_required" {
+  type        = bool
+  description = "Do subscribers need to be approved prior to being able to use the Product?"
+}
+
+variable "published" {
+  type        = bool
+  description = "Is this Product Published?"
+}
+
+variable "policy_xml" {
+  type        = string
+  description = "(Optional) The XML Content for this Product Policy."
+  default     = null
+}
+
+variable "groups" {
+  type        = set(string)
+  description = "(Optional) The groups where the product is included"
+  default     = []
+}

--- a/api_management_product/versions.tf
+++ b/api_management_product/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4"
+    }
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Backporting `azure_management_api` and `azure_management_product` modules from v3

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Continuity with the same modules

### Type of changes

- [X] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
