### PR TITLE
feat: Add feature toggle for auto-dashboard creation

### DIFF
--- a/grafana_dashboard/README.md
+++ b/grafana_dashboard/README.md
@@ -54,6 +54,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_dashboard_directory_path"></a> [dashboard\_directory\_path](#input\_dashboard\_directory\_path) | path for dashboard template | `string` | `"dashboard"` | no |
+| <a name="input_enable_auto_dashboard"></a> [enable\_auto\_dashboard](#input\_enable\_auto\_dashboard) | enable auto dashboard creation | `bool` | `true` | no |
 | <a name="input_grafana_api_key"></a> [grafana\_api\_key](#input\_grafana\_api\_key) | Grafana Managed Service Account key | `string` | n/a | yes |
 | <a name="input_grafana_url"></a> [grafana\_url](#input\_grafana\_url) | Grafana Managed url | `string` | n/a | yes |
 | <a name="input_monitor_workspace_id"></a> [monitor\_workspace\_id](#input\_monitor\_workspace\_id) | Azure Log Analytics workspace id | `string` | n/a | yes |

--- a/grafana_dashboard/README.md
+++ b/grafana_dashboard/README.md
@@ -6,6 +6,19 @@ This module allow the creation of Grafana Dashboard to all "grafana = yes" tagge
 
 ## How to use it
 
+### Configure grafana provider
+
+```ts
+ provider "grafana" {
+  alias = "cloud"
+
+  url  = var.grafana_url
+  auth = var.grafana_auth_api_key
+}
+```
+
+### Import module in your configuration
+
 ```ts
 module "auto_dashboard" {
 

--- a/grafana_dashboard/main.tf
+++ b/grafana_dashboard/main.tf
@@ -1,9 +1,3 @@
-provider "grafana" {
-  alias = "cloud"
-
-  url  = var.grafana_url
-  auth = var.grafana_api_key
-}
 
 locals {
   allowed_resource_by_file = fileset("${path.module}/${var.dashboard_directory_path}", "*.json")
@@ -50,15 +44,13 @@ locals {
 }
 
 resource "grafana_folder" "domainsfolder" {
-  provider = grafana.cloud
-  for_each = var.enable_auto_dashboard ? { for i in range(length(local.dashboard_folder_map)) : local.dashboard_folder_map[i].name => i } : {}
+  for_each = { for i in range(length(local.dashboard_folder_map)) : local.dashboard_folder_map[i].name => i }
 
   title = "${upper(var.prefix)}-${upper(local.dashboard_folder_map[each.value].name)}"
 }
 
 resource "grafana_dashboard" "azure_monitor_grafana" {
-  provider = grafana.cloud
-  for_each = var.enable_auto_dashboard ? { for i in range(length(local.dashboard_resource_map)) : local.dashboard_resource_map[i].name => i } : {}
+  for_each = { for i in range(length(local.dashboard_resource_map)) : local.dashboard_resource_map[i].name => i }
 
   config_json = templatefile(
     "${path.module}/${var.dashboard_directory_path}/${replace(local.dashboard_resource_map[each.value].type, "/", "_")}.json",

--- a/grafana_dashboard/main.tf
+++ b/grafana_dashboard/main.tf
@@ -51,14 +51,14 @@ locals {
 
 resource "grafana_folder" "domainsfolder" {
   provider = grafana.cloud
-  for_each = { for i in range(length(local.dashboard_folder_map)) : local.dashboard_folder_map[i].name => i }
+  for_each = var.enable_auto_dashboard ? { for i in range(length(local.dashboard_folder_map)) : local.dashboard_folder_map[i].name => i } : {}
 
   title = "${upper(var.prefix)}-${upper(local.dashboard_folder_map[each.value].name)}"
 }
 
 resource "grafana_dashboard" "azure_monitor_grafana" {
   provider = grafana.cloud
-  for_each = { for i in range(length(local.dashboard_resource_map)) : local.dashboard_resource_map[i].name => i }
+  for_each = var.enable_auto_dashboard ? { for i in range(length(local.dashboard_resource_map)) : local.dashboard_resource_map[i].name => i } : {}
 
   config_json = templatefile(
     "${path.module}/${var.dashboard_directory_path}/${replace(local.dashboard_resource_map[each.value].type, "/", "_")}.json",

--- a/grafana_dashboard/variables.tf
+++ b/grafana_dashboard/variables.tf
@@ -19,6 +19,12 @@ variable "prefix" {
   description = "product label used for dashboard folder and title"
 }
 
+variable "enable_auto_dashboard" {
+  type        = bool
+  default     = true
+  description = "enable auto dashboard creation"
+}
+
 variable "monitor_workspace_id" {
   type        = string
   description = "Azure Log Analytics workspace id"


### PR DESCRIPTION
### List of changes

- Introduced a new variable `enable_auto_dashboard` to control the conditional creation of Grafana folders and dashboards.

### Motivation and context

This change introduces flexibility by allowing users to enable or disable the automatic creation of dashboards and folders in Grafana according to their specific needs.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine:

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
