### PR TITLE
feat: PAYMCLOUD-394 Add minimal_tls_version variable to CosmosDB module

### DIFF
--- a/cosmosdb_account/README.md
+++ b/cosmosdb_account/README.md
@@ -179,6 +179,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_main_geo_location_location"></a> [main\_geo\_location\_location](#input\_main\_geo\_location\_location) | (Required) The name of the Azure region to host replicated data. | `string` | n/a | yes |
 | <a name="input_main_geo_location_zone_redundant"></a> [main\_geo\_location\_zone\_redundant](#input\_main\_geo\_location\_zone\_redundant) | Should zone redundancy be enabled for main region? Set true for prod environments | `bool` | n/a | yes |
+| <a name="input_minimal_tls_version"></a> [minimal\_tls\_version](#input\_minimal\_tls\_version) | (Optional) Specifies the minimal TLS version for the CosmosDB account. Possible values are: Tls, Tls11, and Tls12. Defaults to Tls12. | `string` | `"Tls12"` | no |
 | <a name="input_mongo_server_version"></a> [mongo\_server\_version](#input\_mongo\_server\_version) | The Server Version of a MongoDB account. Possible values are 4.0, 3.6, and 3.2. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) Specifies the name of the CosmosDB Account. Changing this forces a new resource to be created. | `string` | n/a | yes |
 | <a name="input_offer_type"></a> [offer\_type](#input\_offer\_type) | The CosmosDB account offer type. At the moment can only be set to Standard | `string` | `"Standard"` | no |

--- a/cosmosdb_account/main.tf
+++ b/cosmosdb_account/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_cosmosdb_account" "this" {
   free_tier_enabled          = var.enable_free_tier
   automatic_failover_enabled = var.enable_automatic_failover
   key_vault_key_id           = var.key_vault_key_id
+  minimal_tls_version        = var.minimal_tls_version
 
   mongo_server_version   = var.mongo_server_version
   burst_capacity_enabled = var.burst_capacity_enabled

--- a/cosmosdb_account/variables.tf
+++ b/cosmosdb_account/variables.tf
@@ -56,6 +56,12 @@ variable "mongo_server_version" {
   default     = null
 }
 
+variable "minimal_tls_version" {
+  type        = string
+  description = "(Optional) Specifies the minimal TLS version for the CosmosDB account. Possible values are: Tls, Tls11, and Tls12. Defaults to Tls12."
+  default     = "Tls12"
+}
+
 variable "main_geo_location_location" {
   type        = string
   description = "(Required) The name of the Azure region to host replicated data."


### PR DESCRIPTION
### List of changes

- Added a new variable `minimal_tls_version` to the CosmosDB module to specify the minimum TLS version for a CosmosDB account.
- Defaulted `minimal_tls_version` to TLS 1.2 for enhanced security.

### Motivation and context

This change is required to provide flexibility in enforcing appropriate TLS versions on CosmosDB accounts, ensuring better alignment with security standards.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```