### PR TITLE
fix(vpn): pip_allocation_method default now is Static

### DIFF
--- a/vpn_gateway/README.md
+++ b/vpn_gateway/README.md
@@ -93,7 +93,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | The Azure Region in which to create resource. | `any` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent. | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of virtual gateway. | `any` | n/a | yes |
-| <a name="input_pip_allocation_method"></a> [pip\_allocation\_method](#input\_pip\_allocation\_method) | Defines how the public IP address is allocated. Must be 'Static' for Standard SKU (required by VpnGw1+). | `string` | `"Dynamic"` | no |
+| <a name="input_pip_allocation_method"></a> [pip\_allocation\_method](#input\_pip\_allocation\_method) | Defines how the public IP address is allocated. Must be 'Static' for Standard SKU (required by VpnGw1+). | `string` | `"Static"` | no |
 | <a name="input_pip_id"></a> [pip\_id](#input\_pip\_id) | External public ip | `string` | `null` | no |
 | <a name="input_pip_sku"></a> [pip\_sku](#input\_pip\_sku) | The SKU of the Public IP. Accepted values are Basic and Standard. Defaults to Basic. | `string` | `"Standard"` | no |
 | <a name="input_random_special"></a> [random\_special](#input\_random\_special) | (optional) allows special chars in random string | `bool` | `false` | no |

--- a/vpn_gateway/variables.tf
+++ b/vpn_gateway/variables.tf
@@ -51,7 +51,7 @@ variable "pip_sku" {
 
 variable "pip_allocation_method" {
   description = "Defines how the public IP address is allocated. Must be 'Static' for Standard SKU (required by VpnGw1+)."
-  default     = "Dynamic"
+  default     = "Static"
 
   validation {
     condition = (


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

Pip can be only Static if sku is Standard
### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
