### PR TITLE
feat: [PAYMCLOUD-421] Lowered readiness threshold for `KubePodReadyStateLow` alert from 80% to 50%.

### DIFF
--- a/kubernetes_prometheus_managed/rules/alert_rules_pod.json
+++ b/kubernetes_prometheus_managed/rules/alert_rules_pod.json
@@ -130,7 +130,7 @@
   {
     "alert": "KubePodReadyStateLow",
     "enabled": true,
-    "expression": "sum by (cluster,namespace,deployment)(kube_deployment_status_replicas_ready) / sum by (cluster,namespace,deployment)(kube_deployment_spec_replicas) <.8 or sum by (cluster,namespace,deployment)(kube_daemonset_status_number_ready) / sum by (cluster,namespace,deployment)(kube_daemonset_status_desired_number_scheduled) <.8 ",
+    "expression": "sum by (cluster,namespace,deployment)(kube_deployment_status_replicas_ready) / sum by (cluster,namespace,deployment)(kube_deployment_spec_replicas) <.5 or sum by (cluster,namespace,deployment)(kube_daemonset_status_number_ready) / sum by (cluster,namespace,deployment)(kube_daemonset_status_desired_number_scheduled) <.5 ",
     "severity": 1,
     "severity_label": "error",
     "for": "PT5M",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
