### PR TITLE
feat: [PAYMCLOUD-456] Add PostgreSQL Flexible Server configurations for all cstar environments

### DIFF
--- a/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
@@ -19,7 +19,7 @@ pg_burst_flex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -48,7 +48,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -57,6 +57,64 @@ pgflex2:
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
 pgflex4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: true
+  private_endpoint_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: false
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: true
+  private_endpoint_enabled: false
+  high_availability_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb4:
   sku_name: GP_Standard_D4ds_v5
   db_version: '16'
   storage_mb: '32768'

--- a/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
@@ -1,0 +1,88 @@
+pg_burst_flex2:
+  sku_name: B_Standard_B2s
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  high_availability_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: true
+  private_endpoint_enabled: false
+  high_availability_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: true
+  private_endpoint_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+

--- a/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/dev/postgres_flexible_server.yml
@@ -48,7 +48,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -77,64 +77,6 @@ pgflex4:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
-    pgbouncer_enabled: false
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 1718
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb2:
-  sku_name: GP_Standard_D2ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '7'
-  geo_redundant_backup_enabled: false
-  create_mode: Default
-  max_connections: '859'
-  enable_private_dns_registration: true
-  public_network_access_enabled: true
-  private_endpoint_enabled: false
-  high_availability_enabled: false
-  alerts_enabled: false
-  geo_replication_allowed: false
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 859
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb4:
-  sku_name: GP_Standard_D4ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '7'
-  geo_redundant_backup_enabled: false
-  create_mode: Default
-  max_connections: '1718'
-  enable_private_dns_registration: true
-  public_network_access_enabled: true
-  private_endpoint_enabled: false
-  alerts_enabled: false
-  geo_replication_allowed: false
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: false
-  server_parameters:
     pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
@@ -143,4 +85,3 @@ pgflex_pgb4:
     wal_level: "LOGICAL"
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-

--- a/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
@@ -1,0 +1,116 @@
+pgflex2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  high_availability_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex8:
+  sku_name: GP_Standard_D8ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '3437'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: true
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 3437
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex16:
+  sku_name: GP_Standard_D16ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '5000'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: true
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 5000
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"

--- a/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
@@ -19,7 +19,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -48,7 +48,7 @@ pgflex4:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -77,7 +77,7 @@ pgflex8:
     start_minute: 0
   high_availability_enabled: true
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -86,122 +86,6 @@ pgflex8:
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
 pgflex16:
-  sku_name: GP_Standard_D16ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '30'
-  geo_redundant_backup_enabled: true
-  create_mode: Default
-  max_connections: '5000'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  alerts_enabled: true
-  geo_replication_allowed: true
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: true
-  server_parameters:
-    pgbouncer_enabled: false
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 5000
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb2:
-  sku_name: GP_Standard_D2ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '30'
-  geo_redundant_backup_enabled: true
-  create_mode: Default
-  max_connections: '859'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  high_availability_enabled: true
-  alerts_enabled: true
-  geo_replication_allowed: true
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 859
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb4:
-  sku_name: GP_Standard_D4ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '30'
-  geo_redundant_backup_enabled: true
-  create_mode: Default
-  max_connections: '1718'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  alerts_enabled: true
-  geo_replication_allowed: true
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: false
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 1718
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb8:
-  sku_name: GP_Standard_D8ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '30'
-  geo_redundant_backup_enabled: true
-  create_mode: Default
-  max_connections: '3437'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  alerts_enabled: true
-  geo_replication_allowed: true
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: true
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 3437
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb16:
   sku_name: GP_Standard_D16ds_v5
   db_version: '16'
   storage_mb: '32768'

--- a/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/prod/postgres_flexible_server.yml
@@ -19,7 +19,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -48,7 +48,7 @@ pgflex4:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -77,7 +77,7 @@ pgflex8:
     start_minute: 0
   high_availability_enabled: true
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -86,6 +86,122 @@ pgflex8:
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
 pgflex16:
+  sku_name: GP_Standard_D16ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '5000'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: true
+  server_parameters:
+    pgbouncer_enabled: false
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 5000
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  high_availability_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb8:
+  sku_name: GP_Standard_D8ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '30'
+  geo_redundant_backup_enabled: true
+  create_mode: Default
+  max_connections: '3437'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: true
+  geo_replication_allowed: true
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: true
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 3437
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb16:
   sku_name: GP_Standard_D16ds_v5
   db_version: '16'
   storage_mb: '32768'

--- a/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
@@ -1,0 +1,88 @@
+pgflex2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  high_availability_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex8:
+  sku_name: GP_Standard_D8ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '3437'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 3437
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+

--- a/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
@@ -19,7 +19,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -48,7 +48,7 @@ pgflex4:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
-    pgbouncer_enabled: true
+    pgbouncer_enabled: false
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -77,6 +77,93 @@ pgflex8:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
+    pgbouncer_enabled: false
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 3437
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb2:
+  sku_name: GP_Standard_D2ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '859'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  high_availability_enabled: false
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 859
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb4:
+  sku_name: GP_Standard_D4ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '1718'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
+    pgbouncer_enabled: true
+    max_worker_processes: 16
+    pgbouncer_min_pool_size: 20
+    pgbouncer_default_pool_size: 30
+    pgbouncer_max_client_conn: 1718
+    wal_level: "LOGICAL"
+    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
+    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
+pgflex_pgb8:
+  sku_name: GP_Standard_D8ds_v5
+  db_version: '16'
+  storage_mb: '32768'
+  zone: '1'
+  standby_availability_zone: '2'
+  backup_retention_days: '7'
+  geo_redundant_backup_enabled: false
+  create_mode: Default
+  max_connections: '3437'
+  enable_private_dns_registration: true
+  public_network_access_enabled: false
+  private_endpoint_enabled: true
+  alerts_enabled: false
+  geo_replication_allowed: false
+  maintenance_window_config:
+    day_of_week: 3
+    start_hour: 2
+    start_minute: 0
+  high_availability_enabled: false
+  server_parameters:
     pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
@@ -85,4 +172,3 @@ pgflex8:
     wal_level: "LOGICAL"
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-

--- a/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
+++ b/IDH/00_product_configs/cstar/uat/postgres_flexible_server.yml
@@ -19,7 +19,7 @@ pgflex2:
     start_hour: 2
     start_minute: 0
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -48,7 +48,7 @@ pgflex4:
     start_minute: 0
   high_availability_enabled: false
   server_parameters:
-    pgbouncer_enabled: false
+    pgbouncer_enabled: true
     max_worker_processes: 16
     pgbouncer_min_pool_size: 20
     pgbouncer_default_pool_size: 30
@@ -57,93 +57,6 @@ pgflex4:
     shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
     azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
 pgflex8:
-  sku_name: GP_Standard_D8ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '7'
-  geo_redundant_backup_enabled: false
-  create_mode: Default
-  max_connections: '3437'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  alerts_enabled: false
-  geo_replication_allowed: false
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: false
-  server_parameters:
-    pgbouncer_enabled: false
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 3437
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb2:
-  sku_name: GP_Standard_D2ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '7'
-  geo_redundant_backup_enabled: false
-  create_mode: Default
-  max_connections: '859'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  high_availability_enabled: false
-  alerts_enabled: false
-  geo_replication_allowed: false
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 859
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb4:
-  sku_name: GP_Standard_D4ds_v5
-  db_version: '16'
-  storage_mb: '32768'
-  zone: '1'
-  standby_availability_zone: '2'
-  backup_retention_days: '7'
-  geo_redundant_backup_enabled: false
-  create_mode: Default
-  max_connections: '1718'
-  enable_private_dns_registration: true
-  public_network_access_enabled: false
-  private_endpoint_enabled: true
-  alerts_enabled: false
-  geo_replication_allowed: false
-  maintenance_window_config:
-    day_of_week: 3
-    start_hour: 2
-    start_minute: 0
-  high_availability_enabled: false
-  server_parameters:
-    pgbouncer_enabled: true
-    max_worker_processes: 16
-    pgbouncer_min_pool_size: 20
-    pgbouncer_default_pool_size: 30
-    pgbouncer_max_client_conn: 1718
-    wal_level: "LOGICAL"
-    shared_preload_libraries: "pg_cron,pg_stat_statements,pglogical"
-    azure_extensions: "pg_cron,dblink,pglogical,postgres_fdw"
-pgflex_pgb8:
   sku_name: GP_Standard_D8ds_v5
   db_version: '16'
   storage_mb: '32768'

--- a/IDH/postgres_flexible_server/04_variables.tf
+++ b/IDH/postgres_flexible_server/04_variables.tf
@@ -249,6 +249,6 @@ variable "geo_replication" {
 
 variable "pg_bouncer_enabled" {
   type        = bool
-  default     = false
+  default     = null
   description = "(Optional) Enable or disable PgBouncer. Defaults to false"
 }

--- a/IDH/postgres_flexible_server/04_variables.tf
+++ b/IDH/postgres_flexible_server/04_variables.tf
@@ -246,3 +246,9 @@ variable "geo_replication" {
   }
 
 }
+
+variable "pg_bouncer_enabled" {
+  type        = bool
+  default     = false
+  description = "(Optional) Enable or disable PgBouncer. Defaults to false"
+}

--- a/IDH/postgres_flexible_server/04_variables.tf
+++ b/IDH/postgres_flexible_server/04_variables.tf
@@ -250,5 +250,5 @@ variable "geo_replication" {
 variable "pg_bouncer_enabled" {
   type        = bool
   default     = null
-  description = "(Optional) Enable or disable PgBouncer. Defaults to false"
+  description = "(Optional) Enable or disable PgBouncer. Defaults to false (Server will be restarted on change!)"
 }

--- a/IDH/postgres_flexible_server/LIBRARY.md
+++ b/IDH/postgres_flexible_server/LIBRARY.md
@@ -1,5 +1,20 @@
 # 📚 IDH postgres_flexible_server Resources
 
+## cstar
+| 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
+|:-------------:|:----------------:|:---------:|:----------------|
+| cstar | dev |  pg_burst_flex2 | Postgres v16, sku: B_Standard_B2s, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+|---|---|---|---|
+| cstar | prod |  pgflex16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+|---|---|---|---|
+| cstar | uat |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
 ## dvopla
 | 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
 |:-------------:|:----------------:|:---------:|:----------------|

--- a/IDH/postgres_flexible_server/LIBRARY.md
+++ b/IDH/postgres_flexible_server/LIBRARY.md
@@ -3,18 +3,27 @@
 ## cstar
 | 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
 |:-------------:|:----------------:|:---------:|:----------------|
-| cstar | dev |  pg_burst_flex2 | Postgres v16, sku: B_Standard_B2s, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
-| cstar | dev |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
-| cstar | dev |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pg_burst_flex2 | Postgres v16, sku: B_Standard_B2s, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
+| cstar | dev |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: False |
+| cstar | dev |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: False |
+| cstar | dev |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
 |---|---|---|---|
-| cstar | prod |  pgflex16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
+| cstar | prod |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
+| cstar | prod |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: False |
+| cstar | prod |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
+| cstar | prod |  pgflex_pgb16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex_pgb8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
 |---|---|---|---|
-| cstar | uat |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
-| cstar | uat |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
-| cstar | uat |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
+| cstar | uat |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
+| cstar | uat |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
+| cstar | uat |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex_pgb8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
 ## dvopla
 | 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
 |:-------------:|:----------------:|:---------:|:----------------|

--- a/IDH/postgres_flexible_server/LIBRARY.md
+++ b/IDH/postgres_flexible_server/LIBRARY.md
@@ -4,26 +4,17 @@
 | 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
 |:-------------:|:----------------:|:---------:|:----------------|
 | cstar | dev |  pg_burst_flex2 | Postgres v16, sku: B_Standard_B2s, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
-| cstar | dev |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: False |
-| cstar | dev |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: False |
-| cstar | dev |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
-| cstar | dev |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
+| cstar | dev |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: True, geo replication allowed: False, pg bouncer: True |
 |---|---|---|---|
-| cstar | prod |  pgflex16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
-| cstar | prod |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
-| cstar | prod |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: False |
-| cstar | prod |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: False |
-| cstar | prod |  pgflex_pgb16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: True |
-| cstar | prod |  pgflex_pgb8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex16 | Postgres v16, sku: GP_Standard_D16ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: False, public: False, geo replication allowed: True, pg bouncer: True |
+| cstar | prod |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): True, private dns registration: True, ha: True, public: False, geo replication allowed: True, pg bouncer: True |
 |---|---|---|---|
-| cstar | uat |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
-| cstar | uat |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
-| cstar | uat |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: False |
-| cstar | uat |  pgflex_pgb2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
-| cstar | uat |  pgflex_pgb4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
-| cstar | uat |  pgflex_pgb8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex2 | Postgres v16, sku: GP_Standard_D2ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex4 | Postgres v16, sku: GP_Standard_D4ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
+| cstar | uat |  pgflex8 | Postgres v16, sku: GP_Standard_D8ds_v5, storage: 32768 MB, geo redundant backup (if available): False, private dns registration: True, ha: False, public: False, geo replication allowed: False, pg bouncer: True |
 ## dvopla
 | 🖥️ Product  | 🌍 Environment | 🔤 Tier | 📝 Description |
 |:-------------:|:----------------:|:---------:|:----------------|

--- a/IDH/postgres_flexible_server/README.md
+++ b/IDH/postgres_flexible_server/README.md
@@ -169,7 +169,7 @@ Also handles:
 | <a name="input_location"></a> [location](#input\_location) | (Required) The Azure Region where the PostgreSQL Flexible Server should exist. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created. | `string` | n/a | yes |
-| <a name="input_pg_bouncer_enabled"></a> [pg\_bouncer\_enabled](#input\_pg\_bouncer\_enabled) | (Optional) Enable or disable PgBouncer. Defaults to false | `bool` | `null` | no |
+| <a name="input_pg_bouncer_enabled"></a> [pg\_bouncer\_enabled](#input\_pg\_bouncer\_enabled) | (Optional) Enable or disable PgBouncer. Defaults to false (Server will be restarted on change!) | `bool` | `null` | no |
 | <a name="input_primary_user_assigned_identity_id"></a> [primary\_user\_assigned\_identity\_id](#input\_primary\_user\_assigned\_identity\_id) | Manages a User Assigned Identity | `string` | `null` | no |
 | <a name="input_private_dns_cname_record_ttl"></a> [private\_dns\_cname\_record\_ttl](#input\_private\_dns\_cname\_record\_ttl) | (Optional) if 'private\_dns\_registration' is true, defines the record TTL | `number` | `300` | no |
 | <a name="input_private_dns_record_cname"></a> [private\_dns\_record\_cname](#input\_private\_dns\_record\_cname) | (Optional) if 'private\_dns\_registration' is true, defines the private dns CNAME used to register this server FQDN | `string` | `null` | no |

--- a/IDH/postgres_flexible_server/README.md
+++ b/IDH/postgres_flexible_server/README.md
@@ -169,6 +169,7 @@ Also handles:
 | <a name="input_location"></a> [location](#input\_location) | (Required) The Azure Region where the PostgreSQL Flexible Server should exist. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created. | `string` | n/a | yes |
+| <a name="input_pg_bouncer_enabled"></a> [pg\_bouncer\_enabled](#input\_pg\_bouncer\_enabled) | (Optional) Enable or disable PgBouncer. Defaults to false | `bool` | `false` | no |
 | <a name="input_primary_user_assigned_identity_id"></a> [primary\_user\_assigned\_identity\_id](#input\_primary\_user\_assigned\_identity\_id) | Manages a User Assigned Identity | `string` | `null` | no |
 | <a name="input_private_dns_cname_record_ttl"></a> [private\_dns\_cname\_record\_ttl](#input\_private\_dns\_cname\_record\_ttl) | (Optional) if 'private\_dns\_registration' is true, defines the record TTL | `number` | `300` | no |
 | <a name="input_private_dns_record_cname"></a> [private\_dns\_record\_cname](#input\_private\_dns\_record\_cname) | (Optional) if 'private\_dns\_registration' is true, defines the private dns CNAME used to register this server FQDN | `string` | `null` | no |

--- a/IDH/postgres_flexible_server/README.md
+++ b/IDH/postgres_flexible_server/README.md
@@ -169,7 +169,7 @@ Also handles:
 | <a name="input_location"></a> [location](#input\_location) | (Required) The Azure Region where the PostgreSQL Flexible Server should exist. | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | (Required) The name which should be used for this PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created. | `string` | n/a | yes |
-| <a name="input_pg_bouncer_enabled"></a> [pg\_bouncer\_enabled](#input\_pg\_bouncer\_enabled) | (Optional) Enable or disable PgBouncer. Defaults to false | `bool` | `false` | no |
+| <a name="input_pg_bouncer_enabled"></a> [pg\_bouncer\_enabled](#input\_pg\_bouncer\_enabled) | (Optional) Enable or disable PgBouncer. Defaults to false | `bool` | `null` | no |
 | <a name="input_primary_user_assigned_identity_id"></a> [primary\_user\_assigned\_identity\_id](#input\_primary\_user\_assigned\_identity\_id) | Manages a User Assigned Identity | `string` | `null` | no |
 | <a name="input_private_dns_cname_record_ttl"></a> [private\_dns\_cname\_record\_ttl](#input\_private\_dns\_cname\_record\_ttl) | (Optional) if 'private\_dns\_registration' is true, defines the record TTL | `number` | `300` | no |
 | <a name="input_private_dns_record_cname"></a> [private\_dns\_record\_cname](#input\_private\_dns\_record\_cname) | (Optional) if 'private\_dns\_registration' is true, defines the private dns CNAME used to register this server FQDN | `string` | `null` | no |


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

- Added PostgreSQL Flexible Server configuration files for development (dev), production (prod), and user acceptance testing (UAT) environments.

### Motivation and context

This change is required to introduce specific PostgreSQL Flexible Server configurations for consistent management and setup across different environments (dev, prod, UAT). It will help in ensuring proper environment-specific database configurations.

### Type of changes

- [x] Add new module
- [ ] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```