### PR TITLE
fix: [PAYMCLOUD-457] Allow null value for Redis capacity validation

### DIFF
--- a/IDH/redis/variables.tf
+++ b/IDH/redis/variables.tf
@@ -99,7 +99,7 @@ variable "capacity" {
   default     = null
   description = "(Required) The size of the Redis cache to deploy. Valid values are 0, 1, 2, 3, 4, 5 and 6 for Basic/Standard SKU and 1, 2, 3, 4 for Premium SKU."
   validation {
-    condition     = contains([0, 1, 2, 3, 4, 5, 6], var.capacity)
+    condition     = contains([null, 0, 1, 2, 3, 4, 5, 6], var.capacity)
     error_message = "The capacity value must be one of: 0, 1, 2, 3, 4, 5, 6"
   }
 }


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

- Modified Redis capacity validation to allow `null` values.

### Motivation and context

This change is required to support scenarios where Redis capacity does not need to be explicitly set, providing greater flexibility in configuration.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```