### PR TITLE
faet: [PAYMCLOUD-456] Add support for custom Availability Zone configuration

### DIFF
--- a/IDH/postgres_flexible_server/01_main.tf
+++ b/IDH/postgres_flexible_server/01_main.tf
@@ -9,6 +9,7 @@ module "idh_loader" {
 
 locals {
   pgbouncer_enabled = var.pg_bouncer_enabled != null ? var.pg_bouncer_enabled : module.idh_loader.idh_resource_configuration.server_parameters.pgbouncer_enabled
+  zone              = var.zone != null ? var.zone : module.idh_loader.idh_resource_configuration.zone
 }
 
 # -------------------------------------------------------------------
@@ -32,7 +33,7 @@ module "pgflex" {
   backup_retention_days        = module.idh_loader.idh_resource_configuration.backup_retention_days
   geo_redundant_backup_enabled = contains(module.idh_loader.non_paired_locations, var.location) ? false : module.idh_loader.idh_resource_configuration.geo_redundant_backup_enabled
   create_mode                  = module.idh_loader.idh_resource_configuration.create_mode
-  zone                         = module.idh_loader.idh_resource_configuration.zone
+  zone                         = local.zone
 
   delegated_subnet_id           = module.idh_loader.idh_resource_configuration.private_endpoint_enabled ? var.delegated_subnet_id : null
   private_dns_zone_id           = module.idh_loader.idh_resource_configuration.private_endpoint_enabled ? var.private_dns_zone_id : null
@@ -164,7 +165,7 @@ module "replica" {
   diagnostic_settings_enabled = false
 
   log_analytics_workspace_id = var.log_analytics_workspace_id
-  zone                       = module.idh_loader.idh_resource_configuration.zone
+  zone                       = local.zone
   tags                       = var.tags
 
 }

--- a/IDH/postgres_flexible_server/04_variables.tf
+++ b/IDH/postgres_flexible_server/04_variables.tf
@@ -252,3 +252,9 @@ variable "pg_bouncer_enabled" {
   default     = null
   description = "(Optional) Enable or disable PgBouncer. Defaults to false (Server will be restarted on change!)"
 }
+
+variable "zone" {
+  type        = number
+  default     = null
+  description = "(Optional) The Availability Zone in which the PostgreSQL Flexible Server should be located. (1,2,3)"
+}

--- a/IDH/postgres_flexible_server/README.md
+++ b/IDH/postgres_flexible_server/README.md
@@ -181,6 +181,7 @@ Also handles:
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the Resource Group where the PostgreSQL Flexible Server should exist. | `string` | n/a | yes |
 | <a name="input_storage_mb"></a> [storage\_mb](#input\_storage\_mb) | (Optional) The size of the storage in MB. Changing this forces a new PostgreSQL Flexible Server to be created. | `number` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | (Optional) The Availability Zone in which the PostgreSQL Flexible Server should be located. (1,2,3) | `number` | `null` | no |
 
 ## Outputs
 


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

- Added functionality to support custom Availability Zone configuration in PostgreSQL Flexible Server.

### Motivation and context

This change allows users to specify custom Availability Zones for their PostgreSQL Flexible Server instances, providing improved flexibility and control over resource allocation.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```