### PR TITLE
fix: [PAYMCLOUD-459] Add `lifecycle.ignore_changes` for Event Hub retention description

### DIFF
--- a/eventhub/main.tf
+++ b/eventhub/main.tf
@@ -70,6 +70,13 @@ resource "azurerm_eventhub" "events" {
   namespace_id      = azurerm_eventhub_namespace.this.id
   partition_count   = each.value.partitions
   message_retention = each.value.message_retention
+
+  lifecycle {
+    ignore_changes = [
+      retention_description
+    ]
+  }
+
 }
 
 resource "azurerm_eventhub_consumer_group" "events" {

--- a/eventhub_configuration/main.tf
+++ b/eventhub_configuration/main.tf
@@ -29,6 +29,12 @@ resource "azurerm_eventhub" "events" {
   namespace_id      = data.azurerm_eventhub_namespace.evh_namespace.id
   partition_count   = each.value.partitions
   message_retention = each.value.message_retention
+
+  lifecycle {
+    ignore_changes = [
+      retention_description
+    ]
+  }
 }
 
 #


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

- Introduced a `lifecycle.ignore_changes` block to prevent unnecessary diffs related to Event Hub's retention description.

### Motivation and context

This change helps avoid unnecessary diffs in the Event Hub configuration, ensuring a smoother and more efficient infrastructure management process.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```