### PR TITLE
feat: [PAYMCLOUD-845] Adjust domain roles to include identity-providers permissions

### DIFF
--- a/keycloak_realms_setup/main.tf
+++ b/keycloak_realms_setup/main.tf
@@ -14,12 +14,13 @@ locals {
   domain_admin_composite_roles = [
     "manage-users", "manage-clients", "manage-events", "view-realm",
     "view-users", "query-groups", "query-users", "query-clients",
-    "view-clients", "view-events"
+    "view-clients", "view-events", "manage-identity-providers", "manage-realm",
+    "create-client"
   ]
 
   domain_viewer_composite_roles = [
     "view-realm", "view-users", "query-groups", "query-users",
-    "query-clients", "view-clients", "view-events"
+    "query-clients", "view-clients", "view-events", "view-identity-providers"
   ]
 
   admin_mappers = flatten([


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

Added `view-identity-providers` to `domain_viewer_composite_roles` and `manage-identity-providers` to `domain_admin_composite_roles`.

### Motivation and context

This change ensures that both viewer and admin roles have appropriate permissions related to identity providers. It enhances role functionality and aligns with access control requirements.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

None.

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```