### PR TITLE
fix: [PAYMCLOUD-845] Add roles to domain_admin_composite_roles

### DIFF
--- a/keycloak_realms_setup/main.tf
+++ b/keycloak_realms_setup/main.tf
@@ -14,8 +14,8 @@ locals {
   domain_admin_composite_roles = [
     "manage-users", "manage-clients", "manage-events", "view-realm",
     "view-users", "query-groups", "query-users", "query-clients",
-    "view-clients", "view-events", "manage-identity-providers", "manage-realm",
-    "create-client"
+    "view-clients", "view-events", "manage-identity-providers", "view-identity-providers", "query-realms",
+    "manage-realm", "create-client"
   ]
 
   domain_viewer_composite_roles = [


### PR DESCRIPTION
### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [ ] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module



### List of changes

- Added `view-identity-providers` and `query-realms` roles to `domain_admin_composite_roles`.

### Motivation and context

This change enhances the permissions for domain admin composite roles to provide broader functionality.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

### Other information

N/A

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```