### PR TITLE
fix(storage_account): Ignore network rule added by Defender

### DIFF
--- a/storage_account/main.tf
+++ b/storage_account/main.tf
@@ -108,7 +108,8 @@ resource "azurerm_storage_account" "this" {
   lifecycle {
     ignore_changes = [
       customer_managed_key,
-      immutability_policy.0.state
+      immutability_policy.0.state,
+      network_rules.0.private_link_access, # added by Microsoft Defender for Storage
     ]
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### ⚠️ Attention

The module you changed is also referenced in the IDH folder?

- [x] Yes
- [ ] No

If so, please make sure to update the IDH module as well.

- [ ] I have updated the IDH module

IDH module not updated, as the current change does not require modification.

### List of changes

<!--- Describe your changes in detail -->

Storage Account module: ignore changes in network rule for private link access.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

When enabled, Microsoft Defender adds this network rule to the Storage Account, causing drifts in plans. The module does not allow setting network rule for private link access, so simply ignoring changes seems to be the simplest and safest way.

### Type of changes

- [ ] Add new module
- [x] Update existing module
- [ ] Remove existing module

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

The module does not allow this type of input, so this ignore should not create any difference.

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Run checks

Useful commands to run checks on local machine

```sh
bash .utils/terraform_run_all.sh init local
pre-commit run -a
```
